### PR TITLE
refactor: Update WooCommerce migration UI selectors and handlers

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -233,7 +233,6 @@ jQuery(document).ready(function ($) {
     // migrate now button click
     $(migrateStartBtn).on('click', function (event) {
         event.preventDefault();
-        $('#wc-sales-data-migration-form').submit();
         if (totalItemsMigrateCounts > 0) {
             migrationModal.removeClass('active');
             $('#tlmt-lp-migrate-to-tutor-lms').submit();
@@ -386,8 +385,9 @@ jQuery(document).ready(function ($) {
             AUTO: 'tutor-wc-auto-migrate-tab'
         },
         SELECTORS: {
-            migrationPage: '.tutor-migration-page',
-            migrateBtn: '.migrate-now-btn',
+            migrationPage: '.tutor-migration-page-wc',
+            migrateBtn: '.migrate-now-btn-wc',
+            migrationStartBtn: '#migration-start-btn-wc',
             navLink: '.tutor-nav-link',
             activeNavLink: '.tutor-nav-link.is-active',
             form: '#wc-sales-data-migration-form'
@@ -420,6 +420,21 @@ jQuery(document).ready(function ($) {
     const $wooMigrationPage = $(WOO_CONFIG.SELECTORS.migrationPage);
     const $wooMigrateBtn = $wooMigrationPage.find(WOO_CONFIG.SELECTORS.migrateBtn);
     const $wooCheckboxes = $wooMigrationPage.find(`#${WOO_CONFIG.TABS.CUSTOM} input[type="checkbox"]`);
+
+    $wooMigrateBtn.on('click', function (event) {
+        event.preventDefault();
+
+        migrationModal.addClass('active');
+    });
+
+    $(WOO_CONFIG.SELECTORS.migrationStartBtn).on('click', function (event) {
+        event.preventDefault();
+
+        migrationModal.removeClass('active');
+        $(WOO_CONFIG.SELECTORS.form).submit();
+    });
+
+
 
     // Store original checkbox state
     let wooOriginalCheckboxes = [];

--- a/views/migration_wc.php
+++ b/views/migration_wc.php
@@ -19,7 +19,7 @@ $monetized_by      = get_tutor_option( 'monetize_by' );
 $migration_history = Helper::get_wc_migration_history();
 
 ?>
-<div class="tutor-migration-page">
+<div class="tutor-migration-page-wc">
 
 	<div id="tutor-migration-wrapper">
 		<div class="tutor-migration-area">
@@ -184,10 +184,10 @@ $migration_history = Helper::get_wc_migration_history();
 								</div>
 							</div>
 							<div class="migrate-now-btn-wrapper tutor-col-md-3 tutor-d-flex tutor-justify-end">
-								<span id="total_items_migrate_counts" class="tutor-d-none" data-count="<?php echo esc_attr( $items_count ); ?>"> </span>
+								<span id="total_items_migrate_counts_wc" class="tutor-d-none" data-count="<?php echo esc_attr( $items_count ); ?>"> </span>
 
 								<!-- get active tab using php -->
-								<button type="submit" class="migrate-now-btn tutor-btn tutor-btn-primary" <?php echo esc_attr( $items_count <= 0 ? 'disabled' : '' ); ?>>
+								<button type="submit" class="migrate-now-btn-wc tutor-btn tutor-btn-primary" <?php echo esc_attr( $items_count <= 0 ? 'disabled' : '' ); ?>>
 									<?php esc_html_e( 'Migrate Now', 'tutor-lms-migration-tool' ); ?>
 								</button>
 							</div>
@@ -267,7 +267,7 @@ $migration_history = Helper::get_wc_migration_history();
 							<?php esc_html_e( 'No, Maybe Later!', 'tutor-lms-migration-tool' ); ?>
 						</span>
 					</a>
-					<a href="#" class="migration-start-btn tutor-btn tutor-btn-primary tutor-btn-lg">
+					<a href="#" id="migration-start-btn-wc" class="migration-start-btn-wc tutor-btn tutor-btn-primary tutor-btn-lg">
 						<?php esc_html_e( "Yes, Let's Start", 'tutor-lms-migration-tool' ); ?>
 					</a>
 				</div>


### PR DESCRIPTION
Refactored class and ID selectors for WooCommerce migration elements in both JS and PHP to use '-wc' suffix for clarity and separation from other migration types. Updated event handlers in admin.js to match new selectors and improved modal and form submission logic for the WooCommerce migration flow.